### PR TITLE
hack yolov8 support into jni for use in photon core

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compileCommands": "${workspaceFolder}/opencv_test/compile_commands.json"
+        }
+    ],
+    "version": 4
+}

--- a/src/main/java/org/photonvision/rknn/RknnJNI.java
+++ b/src/main/java/org/photonvision/rknn/RknnJNI.java
@@ -83,7 +83,7 @@ public class RknnJNI {
      * @param modelVer Which model is being used. Detections will be incorrect if not set to corrresponding model.
      * @return
      */
-    public static native long create(String modelPath, int numClasses, ModelVersion modelVer);
+    public static native long create(String modelPath, int numClasses, int modelVer);
     public static native long destroy(long ptr);
 
     /**

--- a/src/main/java/org/photonvision/rknn/RknnJNI.java
+++ b/src/main/java/org/photonvision/rknn/RknnJNI.java
@@ -77,7 +77,7 @@ public class RknnJNI {
      * @param numClasses How many classes. MUST MATCH or native code segfaults
      * @return
      */
-    public static native long create(String modelPath, int numClasses);
+    public static native long create(String modelPath, int numClasses, int model_ver);
     public static native long destroy(long ptr);
 
     /**

--- a/src/main/java/org/photonvision/rknn/RknnJNI.java
+++ b/src/main/java/org/photonvision/rknn/RknnJNI.java
@@ -21,6 +21,11 @@ import org.opencv.core.Point;
 import org.opencv.core.Rect2d;
 
 public class RknnJNI {
+    public static enum ModelVersion {
+        YOLO_V5,
+        YOLO_V8
+    }
+
     public static class RknnResult {
         public RknnResult(
             int left, int top, int right, int bottom, float conf, int class_id
@@ -75,9 +80,10 @@ public class RknnJNI {
      * Create a RKNN detector. Returns valid pointer on success, or NULL on error
      * @param modelPath Absolute path to the model on disk
      * @param numClasses How many classes. MUST MATCH or native code segfaults
+     * @param modelVer Which model is being used. Detections will be incorrect if not set to corrresponding model.
      * @return
      */
-    public static native long create(String modelPath, int numClasses, int model_ver);
+    public static native long create(String modelPath, int numClasses, ModelVersion modelVer);
     public static native long destroy(long ptr);
 
     /**

--- a/src/main/native/cpp/rknn_jni.cpp
+++ b/src/main/native/cpp/rknn_jni.cpp
@@ -62,12 +62,12 @@ static jobject MakeJObject(JNIEnv *env, const detect_result_t &result) {
  */
 JNIEXPORT jlong JNICALL
 Java_org_photonvision_rknn_RknnJNI_create
-  (JNIEnv *env, jclass, jstring javaString, jint numClasses)
+  (JNIEnv *env, jclass, jstring javaString, jint numClasses, jint model_ver)
 {
   const char *nativeString = env->GetStringUTFChars(javaString, 0);
   std::printf("Creating for %s\n", nativeString);
 
-  auto ret = new RknnWrapper(nativeString, numClasses);
+  auto ret = new RknnWrapper(nativeString, numClasses, model_ver);
   env->ReleaseStringUTFChars(javaString, nativeString);
   return reinterpret_cast<jlong>(ret);
 }

--- a/src/main/native/cpp/rknn_jni.cpp
+++ b/src/main/native/cpp/rknn_jni.cpp
@@ -62,12 +62,12 @@ static jobject MakeJObject(JNIEnv *env, const detect_result_t &result) {
  */
 JNIEXPORT jlong JNICALL
 Java_org_photonvision_rknn_RknnJNI_create
-  (JNIEnv *env, jclass, jstring javaString, jint numClasses, jint model_ver)
+  (JNIEnv *env, jclass, jstring javaString, jint numClasses, jint modelVer)
 {
   const char *nativeString = env->GetStringUTFChars(javaString, 0);
   std::printf("Creating for %s\n", nativeString);
 
-  auto ret = new RknnWrapper(nativeString, numClasses, model_ver);
+  auto ret = new RknnWrapper(nativeString, numClasses, reinterpret_cast<ModelVersion>(modelVer));
   env->ReleaseStringUTFChars(javaString, nativeString);
   return reinterpret_cast<jlong>(ret);
 }

--- a/src/main/native/cpp/yolov8/postprocess.cc
+++ b/src/main/native/cpp/yolov8/postprocess.cc
@@ -23,6 +23,7 @@
 
 #include <set>
 #include <vector>
+#include "include/postprocess.h"
 #define LABEL_NALE_TXT_PATH "./model/coco_80_labels_list.txt"
 
 static char *labels[OBJ_CLASS_NUM];
@@ -351,7 +352,7 @@ static int process_fp32(float *box_tensor, float *score_tensor, float *score_sum
 }
 
 
-int post_process(rknn_app_context_t *app_ctx, rknn_output *outputs, BOX_RECT *padding, float conf_threshold, float nms_threshold, object_detect_result_list *od_results)
+int post_process(rknn_app_context_t *app_ctx, rknn_output *outputs, BOX_RECT *padding, float conf_threshold, float nms_threshold, detect_result_group_t *od_results)
 {
     std::vector<float> filterBoxes;
     std::vector<float> objProbs;
@@ -363,7 +364,7 @@ int post_process(rknn_app_context_t *app_ctx, rknn_output *outputs, BOX_RECT *pa
     int model_in_w = app_ctx->model_width;
     int model_in_h = app_ctx->model_height;
 
-    memset(od_results, 0, sizeof(object_detect_result_list));
+    memset(od_results, 0, sizeof(detect_result_group_t));
 
     // default 3 branch
     int dfl_len = app_ctx->output_attrs[0].dims[1] /4;
@@ -451,8 +452,8 @@ int post_process(rknn_app_context_t *app_ctx, rknn_output *outputs, BOX_RECT *pa
         od_results->results[last_count].box.top = (int)(clamp(y1, 0, model_in_h) / rect_scale);
         od_results->results[last_count].box.right = (int)(clamp(x2, 0, model_in_w) / rect_scale);
         od_results->results[last_count].box.bottom = (int)(clamp(y2, 0, model_in_h) / rect_scale);
-        od_results->results[last_count].prop = obj_conf;
-        od_results->results[last_count].cls_id = id;
+        od_results->results[last_count].obj_conf = obj_conf;
+        od_results->results[last_count].id = id;
         last_count++;
     }
     od_results->count = last_count;

--- a/src/main/native/cpp/yolov8/yolov8.cc
+++ b/src/main/native/cpp/yolov8/yolov8.cc
@@ -161,7 +161,7 @@ int release_yolov8_model(rknn_app_context_t *app_ctx)
     return 0;
 }
 
-int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, object_detect_result_list *od_results, DetectionFilterParams params)
+int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, detect_result_group_t *od_results, DetectionFilterParams params)
 {
     int ret;
     cv::Mat img;

--- a/src/main/native/cpp/yolov8/yolov8.cc
+++ b/src/main/native/cpp/yolov8/yolov8.cc
@@ -164,7 +164,8 @@ int release_yolov8_model(rknn_app_context_t *app_ctx)
 int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, object_detect_result_list *od_results, DetectionFilterParams params)
 {
     int ret;
-    image_buffer_t dst_img;
+    cv::Mat img;
+    // what do we do with this?
     letterbox_t letter_box;
     rknn_input inputs[app_ctx->io_num.n_input];
     rknn_output outputs[app_ctx->io_num.n_output];
@@ -172,47 +173,62 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
     const float box_conf_threshold = params.box_thresh;
     int bg_color = 114;
 
-    if ((!app_ctx) || !(img) || (!od_results))
+    if ((!app_ctx) || !(orig_img) || (!od_results))
     {
         return -1;
     }
 
-    // dealt with in cv mat
-    memset(od_results, 0x00, sizeof(*od_results));
-    memset(&letter_box, 0, sizeof(letterbox_t));
-    memset(&dst_img, 0, sizeof(image_buffer_t));
-    memset(inputs, 0, sizeof(inputs));
-    memset(outputs, 0, sizeof(outputs));
+    // get model desired width/height
+    width = app_ctx->model_width;
+    height = app_ctx->model_height;
 
-    // Pre Process
-    // this is all dealt with in cv mat
-    dst_img.width = app_ctx->model_width;
-    dst_img.height = app_ctx->model_height;
-    dst_img.format = IMAGE_FORMAT_RGB888;
-    dst_img.size = get_image_size(&dst_img);
-    dst_img.virt_addr = (unsigned char *)malloc(dst_img.size);
-    if (dst_img.virt_addr == NULL)
+    // rknn wants RGB, cameras usually give BGR
+    cv::cvtColor(orig_img, img, cv::COLOR_BGR2RGB);
+    // get current width/height
+    img_width = img.cols;
+    img_height = img.rows;
+
+    BOX_RECT padding;
+    memset(&padding, 0, sizeof(BOX_RECT));
+
+    cv::Size target_size(width, height);
+    // create 8 bit 3 channel buffer
+    cv::Mat resized_img(target_size.height, target_size.width, CV_8UC3);
+
+    // Calculate scaling ratio
+    float scale_w = (float)target_size.width / img.cols;
+    float scale_h = (float)target_size.height / img.rows;
+
+    // if input doesn't match model desired
+    if (img_width != width || img_height != height)
     {
-        printf("malloc buffer size:%d fail!\n", dst_img.size);
-        return -1;
+        // rga
+        rga_buffer_t src;
+        rga_buffer_t dst;
+        memset(&src, 0, sizeof(src));
+        memset(&dst, 0, sizeof(dst));
+        ret = resize_rga(src, dst, img, resized_img, target_size);
+        if (ret != 0)
+        {
+            fprintf(stderr, "resize with rga error\n");
+        }
+        /*********
+        // opencv
+        // ripped from v5, why do we not letterbox???
+        float min_scale = std::min(scale_w, scale_h);
+        scale_w = min_scale;
+        scale_h = min_scale;
+        letterbox(img, resized_img, pads, min_scale, target_size);
+        *********/
+        inputs[0].buf = resized_img.data;
+    }
+    else
+    {
+        // otherwise just send the image as is
+        inputs[0].buf = img.data;
     }
 
-    // letterbox
-    // padded image (aka letterbox_t) also needs to be cv mat
-    ret = convert_image_with_letterbox(img, &dst_img, &letter_box, bg_color);
-    if (ret < 0)
-    {
-        printf("convert_image_with_letterbox fail! ret=%d\n", ret);
-        return -1;
-    }
-
-    // Set Input Data (shouldnt be necessary, just need to set buf to img.data)
-    inputs[0].index = 0;
-    inputs[0].type = RKNN_TENSOR_UINT8;
-    inputs[0].fmt = RKNN_TENSOR_NHWC;
-    inputs[0].size = app_ctx->model_width * app_ctx->model_height * app_ctx->model_channel;
-    inputs[0].buf = dst_img.virt_addr;
-
+    // load our image into npu
     ret = rknn_inputs_set(app_ctx->rknn_ctx, app_ctx->io_num.n_input, inputs);
     if (ret < 0)
     {
@@ -220,7 +236,7 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
         return -1;
     }
 
-    // Run
+    // send it
     printf("rknn_run\n");
     ret = rknn_run(app_ctx->rknn_ctx, nullptr);
     if (ret < 0)
@@ -229,13 +245,15 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
         return -1;
     }
 
-    // Get Output
+    // prep output storage
     memset(outputs, 0, sizeof(outputs));
     for (int i = 0; i < app_ctx->io_num.n_output; i++)
     {
         outputs[i].index = i;
         outputs[i].want_float = (!app_ctx->is_quant);
     }
+
+    // read outputs from npu
     ret = rknn_outputs_get(app_ctx->rknn_ctx, app_ctx->io_num.n_output, outputs, NULL);
     if (ret < 0)
     {
@@ -244,9 +262,10 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
     }
 
     // Post Process
+    // TODO: look into why this needs the letterbox_t struct
     post_process(app_ctx, outputs, &letter_box, box_conf_threshold, nms_threshold, od_results);
 
-    // Remeber to release rknn output
+    // release rknn output
     rknn_outputs_release(app_ctx->rknn_ctx, app_ctx->io_num.n_output, outputs);
 
 out:

--- a/src/main/native/cpp/yolov8/yolov8.cc
+++ b/src/main/native/cpp/yolov8/yolov8.cc
@@ -165,8 +165,9 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
 {
     int ret;
     cv::Mat img;
-    // what do we do with this?
-    letterbox_t letter_box;
+    BOX_RECT padding;
+    memset(&padding, 0, sizeof(BOX_RECT));
+
     rknn_input inputs[app_ctx->io_num.n_input];
     rknn_output outputs[app_ctx->io_num.n_output];
     const float nms_threshold = params.nms_thresh;
@@ -187,9 +188,6 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
     // get current width/height
     img_width = img.cols;
     img_height = img.rows;
-
-    BOX_RECT padding;
-    memset(&padding, 0, sizeof(BOX_RECT));
 
     cv::Size target_size(width, height);
     // create 8 bit 3 channel buffer
@@ -218,7 +216,7 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
         float min_scale = std::min(scale_w, scale_h);
         scale_w = min_scale;
         scale_h = min_scale;
-        letterbox(img, resized_img, pads, min_scale, target_size);
+        letterbox(img, resized_img, padding, min_scale, target_size);
         *********/
         inputs[0].buf = resized_img.data;
     }
@@ -262,8 +260,7 @@ int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, objec
     }
 
     // Post Process
-    // TODO: look into why this needs the letterbox_t struct
-    post_process(app_ctx, outputs, &letter_box, box_conf_threshold, nms_threshold, od_results);
+    post_process(app_ctx, outputs, &padding, box_conf_threshold, nms_threshold, od_results);
 
     // release rknn output
     rknn_outputs_release(app_ctx->rknn_ctx, app_ctx->io_num.n_output, outputs);

--- a/src/main/native/cpp/yolov8/yolov8.h
+++ b/src/main/native/cpp/yolov8/yolov8.h
@@ -18,8 +18,12 @@
 
 #include "rknn_api.h"
 #include "common.h"
+#include "postprocess.h"
 
-typedef struct {
+class rkYolov8s
+{
+private:
+ typedef struct {
     rknn_context rknn_ctx;
     rknn_input_output_num io_num;
     rknn_tensor_attr* input_attrs;
@@ -29,14 +33,30 @@ typedef struct {
     int model_height;
     bool is_quant;
 } rknn_app_context_t;
+rknn_app_context_t context;
 
-#include "postprocess.h"
+public:
+    // rkYolov5s(const std::string &model_path, int numClasses);
+
+    int init(const char* model_path) {
+        init_yolov8_model(model_path, &context)
+    }
+    int init_yolov8_model(const char* model_path, rknn_app_context_t* app_ctx);
+
+    // rknn_context *get_pctx();
+
+    /**
+     * Run forward inference only, returning resulting detections
+    */
+    // int inferOnly(cv::Mat &orig_img, detect_result_group_t *outReults, DetectionFilterParams params);
+    int inference_yolov8_model(rknn_app_context_t* app_ctx, image_buffer_t* img, object_detect_result_list* od_results);
+
+    // ~rkYolov5s();
+    int release_yolov8_model(rknn_app_context_t* app_ctx);
+};
 
 
-int init_yolov8_model(const char* model_path, rknn_app_context_t* app_ctx);
 
-int release_yolov8_model(rknn_app_context_t* app_ctx);
 
-int inference_yolov8_model(rknn_app_context_t* app_ctx, image_buffer_t* img, object_detect_result_list* od_results);
 
 #endif //_RKNN_DEMO_YOLOV8_H_

--- a/src/main/native/cpp/yolov8/yolov8.h
+++ b/src/main/native/cpp/yolov8/yolov8.h
@@ -19,6 +19,7 @@
 #include "rknn_api.h"
 #include "common.h"
 #include "postprocess.h"
+#include "include/postprocess.h"
 
 class rkYolov8s
 {
@@ -38,10 +39,11 @@ rknn_app_context_t context;
 public:
     // rkYolov5s(const std::string &model_path, int numClasses);
 
-    int init(const char* model_path) {
-        init_yolov8_model(model_path, &context)
-    }
     int init_yolov8_model(const char* model_path, rknn_app_context_t* app_ctx);
+
+    int init(const char* model_path) {
+        return init_yolov8_model(model_path, &context)
+    }
 
     // rknn_context *get_pctx();
 
@@ -49,14 +51,30 @@ public:
      * Run forward inference only, returning resulting detections
     */
     // int inferOnly(cv::Mat &orig_img, detect_result_group_t *outReults, DetectionFilterParams params);
+
     int inference_yolov8_model(rknn_app_context_t* app_ctx, image_buffer_t* img, object_detect_result_list* od_results);
+    
+    int infer(cv::Mat &img, detect_result_group_t* result_ptr, DetectionFilterParams params) {
+        image_buffer_t image_buf;
+        object_detect_result_list results;
 
-    // ~rkYolov5s();
+        //TODO: convert cv matrix to image_buffer_t
+        int ret = inference_yolov8_model(&context, image_buf, &results);
+        
+        //TODO: put object_detect_result_list into detect_result_group_t
+        // this syntax to deref and access struct members might be wrong ive fallen off ;-;
+        result_ptr->id = -1;
+        result_ptr->count = -1;
+        result_ptr->results = -1;
+        
+        return ret;
+    }
+
     int release_yolov8_model(rknn_app_context_t* app_ctx);
+
+    ~rkYolov8s() {
+        release_yolov8_model(&context);
+    }
 };
-
-
-
-
 
 #endif //_RKNN_DEMO_YOLOV8_H_

--- a/src/main/native/cpp/yolov8/yolov8.h
+++ b/src/main/native/cpp/yolov8/yolov8.h
@@ -52,23 +52,9 @@ public:
     */
     // int inferOnly(cv::Mat &orig_img, detect_result_group_t *outReults, DetectionFilterParams params);
 
-    int inference_yolov8_model(rknn_app_context_t* app_ctx, image_buffer_t* img, object_detect_result_list* od_results);
-    
-    int infer(cv::Mat &img, detect_result_group_t* result_ptr, DetectionFilterParams params) {
-        image_buffer_t image_buf;
-        object_detect_result_list results;
-
-        //TODO: change inference method to use cv mat
-        int ret = inference_yolov8_model(&context, image_buf, &results);
-        
-        //TODO: put object_detect_result_list into detect_result_group_t
-        // we have to do this because post uses result_group
-        // this syntax to deref and access struct members might be wrong ive fallen off ;-;
-        result_ptr->id = -1;
-        result_ptr->count = -1;
-        result_ptr->results = -1;
-        
-        return ret;
+    int inference_yolov8_model(rknn_app_context_t *app_ctx, cv::Mat &orig_img, detect_result_group_t *od_results, DetectionFilterParams params);
+    int infer(cv::Mat &orig_img, detect_result_group_t *od_results, DetectionFilterParams params) {
+        return inference_yolov8_model(&context, orig_img, od_results, params);
     }
 
     int release_yolov8_model(rknn_app_context_t* app_ctx);

--- a/src/main/native/cpp/yolov8/yolov8.h
+++ b/src/main/native/cpp/yolov8/yolov8.h
@@ -58,10 +58,11 @@ public:
         image_buffer_t image_buf;
         object_detect_result_list results;
 
-        //TODO: convert cv matrix to image_buffer_t
+        //TODO: change inference method to use cv mat
         int ret = inference_yolov8_model(&context, image_buf, &results);
         
         //TODO: put object_detect_result_list into detect_result_group_t
+        // we have to do this because post uses result_group
         // this syntax to deref and access struct members might be wrong ive fallen off ;-;
         result_ptr->id = -1;
         result_ptr->count = -1;

--- a/src/main/native/include/rknn_wrapper.h
+++ b/src/main/native/include/rknn_wrapper.h
@@ -7,18 +7,29 @@
 #include "opencv2/imgproc/imgproc.hpp"
 #include "rkYolov5s.hpp"
 #include "rknnPool.hpp"
+#include "yolov8/yolov8.h"
 #include <optional>
 
 class RknnWrapper
 {
 private:
-    rkYolov5s yolo;
+    rkYolov5s yolov5;
+    rkYolov8s yolov8;
     int m_numClasses;
 
 public:
-    RknnWrapper(const char *model_name, int numClasses, int model_ver) : yolo(model_name, numClasses)
+    RknnWrapper(const char *model_name, int numClasses, int model_ver)
     { 
-        yolo.init(yolo.get_pctx(), false);
+        switch (model_ver) {
+            case 5:
+                yolov5 = rkYolov5s(model_name, numClasses);
+                yolov5.init(yolov5.get_pctx(), false);
+            break;
+            case 8:
+                yolov8 = rkYolov8s();
+                yolov8.init(model_name);
+            break;
+        }
     }
 
     detect_result_group_t forward(cv::Mat &img, DetectionFilterParams params) {

--- a/src/main/native/include/rknn_wrapper.h
+++ b/src/main/native/include/rknn_wrapper.h
@@ -16,7 +16,7 @@ private:
     int m_numClasses;
 
 public:
-    RknnWrapper(const char *model_name, int numClasses) : yolo(model_name, numClasses)
+    RknnWrapper(const char *model_name, int numClasses, int model_ver) : yolo(model_name, numClasses)
     { 
         yolo.init(yolo.get_pctx(), false);
     }

--- a/src/main/native/include/rknn_wrapper.h
+++ b/src/main/native/include/rknn_wrapper.h
@@ -10,6 +10,11 @@
 #include "yolov8/yolov8.h"
 #include <optional>
 
+enum ModelVersion {
+    YOLO_V5,
+    YOLO_V8
+};
+
 class RknnWrapper
 {
 private:
@@ -18,14 +23,14 @@ private:
     int m_numClasses;
 
 public:
-    RknnWrapper(const char *model_name, int numClasses, int model_ver)
+    RknnWrapper(const char *model_name, int numClasses, ModelVersion model_ver)
     { 
         switch (model_ver) {
-            case 5:
+            case YOLO_V5:
                 yolov5 = rkYolov5s(model_name, numClasses);
                 yolov5.init(yolov5.get_pctx(), false);
             break;
-            case 8:
+            case YOLO_V8:
                 yolov8 = rkYolov8s();
                 yolov8.init(model_name);
             break;
@@ -34,7 +39,7 @@ public:
 
     detect_result_group_t forward(cv::Mat &img, DetectionFilterParams params) {
         detect_result_group_t ret;
-        int code = yolo.inferOnly(img, &ret, params);
+        int code = yolov5.inferOnly(img, &ret, params);
         return ret;
     }
 

--- a/src/main/native/include/rknn_wrapper.h
+++ b/src/main/native/include/rknn_wrapper.h
@@ -39,10 +39,19 @@ public:
 
     detect_result_group_t forward(cv::Mat &img, DetectionFilterParams params) {
         detect_result_group_t ret;
-        int code = yolov5.inferOnly(img, &ret, params);
+        int code;
+        switch (model_ver) {
+            case YOLO_V5:
+                code = yolov5.inferOnly(img, &ret, params);
+            break;
+            case YOLO_V8:
+                code = yolov8.infer(img, &ret, params);
+            break;
+        }
         return ret;
     }
 
     // Let the rkYolov5s dtor take care of cleanup
+    // how to destroy yolov8 processor?????
     ~RknnWrapper() = default;
 };

--- a/src/test/java/org/photonvision/rknn/RknnTest.java
+++ b/src/test/java/org/photonvision/rknn/RknnTest.java
@@ -32,6 +32,7 @@ import org.opencv.core.Size;
 import org.opencv.dnn.Dnn;
 import org.opencv.dnn.Net;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.photonvision.rknn.RknnJNI.ModelVersion;
 
 import edu.wpi.first.cscore.CvSink;
 import edu.wpi.first.cscore.CvSource;
@@ -79,7 +80,7 @@ public class RknnTest {
         System.load("/home/coolpi/rknn_jni/cmake_build/librknn_jni.so");
 
         System.out.println("Creating detector");
-        long ptr = RknnJNI.create("/home/coolpi/rknn_jni/note-640-640-yolov5s.rknn", 1);
+        long ptr = RknnJNI.create("/home/coolpi/rknn_jni/note-640-640-yolov5s.rknn", 1, ModelVersion.YOLO_V5);
         
         System.out.println("Running detector");
         var ret = RknnJNI.detect(ptr, img.getNativeObjAddr(), .45, .25);

--- a/src/test/java/org/photonvision/rknn/RknnTest.java
+++ b/src/test/java/org/photonvision/rknn/RknnTest.java
@@ -80,7 +80,8 @@ public class RknnTest {
         System.load("/home/coolpi/rknn_jni/cmake_build/librknn_jni.so");
 
         System.out.println("Creating detector");
-        long ptr = RknnJNI.create("/home/coolpi/rknn_jni/note-640-640-yolov5s.rknn", 1, ModelVersion.YOLO_V5);
+        // my java has fallen off, theres gotta be a way for java to autocast without an explicit ordinal call???
+        long ptr = RknnJNI.create("/home/coolpi/rknn_jni/note-640-640-yolov5s.rknn", 1, ModelVersion.YOLO_V5.ordinal());
         
         System.out.println("Running detector");
         var ret = RknnJNI.detect(ptr, img.getNativeObjAddr(), .45, .25);


### PR DESCRIPTION
This implementation uses the inference implementation provided by Rockchip found here: https://github.com/airockchip/rknn_model_zoo/tree/main/examples/yolov8/cpp

From the perspective of the back end it just adds another parameter specifying which model version is being used, and the classes used natively will change based on the parameter/model.

~~There will be some additional overhead when using v8 models since the Rockchip implementation uses their own matrix structures for image processing, so there has to be some conversion between cv::Mat and Rockchip's image_buffer_t...~~

EDIT: Changed v8 implementation to use OpenCV matrix and other post-processing structs, no conversion needed 🎉