### PR TITLE
Handle all potential NPU core masks

### DIFF
--- a/src/main/native/cpp/yolo_common.cpp
+++ b/src/main/native/cpp/yolo_common.cpp
@@ -95,6 +95,9 @@ YoloModel::YoloModel(std::string modelPath, int num_classes_, ModelVersion type_
     case 2:
         core_mask = RKNN_NPU_CORE_2;
         break;
+    default:
+        core_mask = RKNN_NPU_CORE_AUTO;
+        break;
     }
     ret = rknn_set_core_mask(ctx, core_mask);
     if (ret < 0)

--- a/src/main/native/cpp/yolo_common.cpp
+++ b/src/main/native/cpp/yolo_common.cpp
@@ -86,6 +86,9 @@ YoloModel::YoloModel(std::string modelPath, int num_classes_, ModelVersion type_
     rknn_core_mask core_mask;
     switch (coreNumber)
     {
+    case -1:
+        core_mask = RKNN_NPU_CORE_AUTO;
+        break;
     case 0:
         core_mask = RKNN_NPU_CORE_0;
         break;
@@ -102,7 +105,7 @@ YoloModel::YoloModel(std::string modelPath, int num_classes_, ModelVersion type_
         core_mask = RKNN_NPU_CORE_0_1_2;
         break;
     default:
-        core_mask = RKNN_NPU_CORE_AUTO;
+        throw std::runtime_error("invalid core selection! core selected: " + coreNumber);
         break;
     }
     ret = rknn_set_core_mask(ctx, core_mask);

--- a/src/main/native/cpp/yolo_common.cpp
+++ b/src/main/native/cpp/yolo_common.cpp
@@ -95,6 +95,12 @@ YoloModel::YoloModel(std::string modelPath, int num_classes_, ModelVersion type_
     case 2:
         core_mask = RKNN_NPU_CORE_2;
         break;
+    case 10:
+        core_mask = RKNN_NPU_CORE_0_1;
+        break;
+    case 210:
+        core_mask = RKNN_NPU_CORE_0_1_2;
+        break;
     default:
         core_mask = RKNN_NPU_CORE_AUTO;
         break;


### PR DESCRIPTION
Previously, we only allowed the driver to run a model on core 0, 1, or 2. This adds cases for running a model in dual-core or tri-core configurations, with a default case to enable automatic load balancing by the NPU.