### PR TITLE
Use WPILib native library packaging format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,14 +73,14 @@ test {
     }
 }
 
-ext.nativeName = wpilibTools.platformMapper.currentPlatform.platformName;
+ext.nativeName = wpilibTools.platformMapper.currentPlatform.platformName.replace('win', 'windows/').replace('mac', 'osx/').replace('linux', 'linux/').replace('x64', 'x86-64');
 ext.outputsFolder = file("$buildDir/outputs")
 
 println("Building for $nativeName")
 
 tasks.register('copyNativeLibrary', Sync) {
     from "${projectDir}/cmake_build/lib"
-    into "${outputsFolder}/nativelibraries/${nativeName}/"
+    into "${outputsFolder}/${nativeName}/shared"
     include "**/*.so"
 
     // And flatten, since windows is stupid


### PR DESCRIPTION
We're changing to use the wpilib native packaging in https://github.com/PhotonVision/photonvision/pull/2223, this reflects that.