### PR TITLE
2027

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,15 +45,14 @@ jobs:
       run: git fetch --tags --force
     - run: git describe --tags
 
-    - name: Install Java 17
-      uses: actions/setup-java@v5
+    - uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 25
         distribution: temurin
 
     - run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential default-jdk openjdk-17-jdk binutils
+        sudo apt-get install -y cmake build-essential default-jdk openjdk-25-jdk binutils
         ls
         find .
         pwd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,7 @@ set(LIB_ARCH aarch64)
 set(RGA_PATH ${CMAKE_SOURCE_DIR}/src/main/native/lib/3rdparty/rga/RK3588)
 set(RGA_LIB ${RGA_PATH}/lib/Linux/${LIB_ARCH}/librga.so)
 
-set(OPENCV_YEAR "frc2025")
-set(OPENCV_VERSION "4.10.0-3")
+set(OPENCV_VERSION "2027-4.13.0-3")
 # also valid: windowsx86-64
 
 # type can be "", "debug", "static", or "staticdebug"
@@ -48,7 +47,7 @@ include(FetchContent)
 FetchContent_Declare(
     opencv_lib
     URL
-        https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/${OPENCV_YEAR}/opencv/opencv-cpp/${OPENCV_VERSION}/opencv-cpp-${OPENCV_VERSION}-${OPENCV_ARCH}${OPENCV_TYPE}.zip
+        https://frcmaven.wpi.edu/artifactory/release/org/wpilib/thirdparty/opencv/opencv-cpp/${OPENCV_VERSION}/opencv-cpp-${OPENCV_VERSION}-${OPENCV_ARCH}${OPENCV_TYPE}.zip
 )
 FetchContent_MakeAvailable(opencv_lib)
 
@@ -56,7 +55,7 @@ FetchContent_MakeAvailable(opencv_lib)
 FetchContent_Declare(
     opencv_header
     URL
-        https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/thirdparty/${OPENCV_YEAR}/opencv/opencv-cpp/${OPENCV_VERSION}/opencv-cpp-${OPENCV_VERSION}-headers.zip
+        https://frcmaven.wpi.edu/artifactory/release/org/wpilib/thirdparty/opencv/opencv-cpp/${OPENCV_VERSION}/opencv-cpp-${OPENCV_VERSION}-headers.zip
 )
 FetchContent_MakeAvailable(opencv_header)
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ spotless {
         toggleOffOn()
         googleJavaFormat()
         leadingSpacesToTabs(2)
-        leadingSpacesToTabs(4)
+        leadingTabsToSpaces(4)
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,8 @@
 plugins {
     id "java"
-    id 'org.photonvision.tools.WpilibTools' version '2.3.1-photon'
-    id "edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin" version "2020.2"
+    id 'org.photonvision.tools.WpilibTools' version '4.1.1-photon'
+    id "org.wpilib.WPILibRepositoriesPlugin" version "2027.0.0"
     id "com.diffplug.spotless" version "8.1.0"
-    id "edu.wpi.first.GradleRIO" version "2026.1.1"
 }
 
 allprojects {
@@ -12,6 +11,7 @@ allprojects {
         mavenLocal()
         maven { url = "https://maven.photonvision.org/repository/internal/" }
     }
+    wpilibRepositories.use2027Repos()
     wpilibRepositories.addAllReleaseRepositories(it)
     wpilibRepositories.addAllDevelopmentRepositories(it)
 }
@@ -22,16 +22,8 @@ apply from: "versioningHelper.gradle"
 ext {
     pubVersion = versionString
     isDev = pubVersion.startsWith("dev")
-
-    wpilibVersion = "2026.1.1"
-    wpimathVersion = wpilibVersion
-    openCVversion = "4.10.0-3"
+    openCVversion = "2027-4.13.0-3"
 }
-
-wpi.getVersions().getOpencvVersion().convention(openCVversion);
-wpi.getVersions().getWpilibVersion().convention(wpilibVersion);
-wpi.getVersions().getWpimathVersion().convention(wpimathVersion);
-wpilibTools.deps.wpilibVersion = wpilibVersion
 
 java {
     sourceCompatibility = JavaVersion.VERSION_25
@@ -46,11 +38,9 @@ dependencies {
 
     implementation wpilibTools.deps.wpilibJava("wpiutil")
     testImplementation wpilibTools.deps.wpilibJava("cscore")
+    testImplementation 'org.photonvision:photon-targeting-java:v2026.3.2'
 
-    implementation wpilibTools.deps.wpilibOpenCvJava("frc2025", wpi.versions.opencvVersion.get())
-    testImplementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: wpi.versions.jacksonVersion.get()
-    testImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: wpi.versions.jacksonVersion.get()
-    testImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: wpi.versions.jacksonVersion.get()
+    implementation wpilibTools.deps.wpilibOpenCvJava(openCVversion)
 }
 
 tasks.withType(JavaCompile) {
@@ -105,12 +95,12 @@ spotless {
     java {
         target fileTree('.') {
             include '**/*.java'
-            exclude '**/build/**', '**/build-*/**', '**/src/generated/**'
+            exclude '**/build/**', '**/build-*/**', '**/src/generated/**', '**/cmake_build/**'
         }
         toggleOffOn()
         googleJavaFormat()
-        indentWithTabs(2)
-        indentWithSpaces(4)
+        leadingSpacesToTabs(2)
+        leadingSpacesToTabs(4)
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()
@@ -121,7 +111,7 @@ spotless {
             exclude '**/build/**', '**/build-*/**'
         }
         greclipse()
-        indentWithSpaces(4)
+        leadingTabsToSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()
     }
@@ -131,7 +121,7 @@ spotless {
             exclude '**/build/**', '**/build-*/**'
         }
         trimTrailingWhitespace()
-        indentWithSpaces(2)
+        leadingTabsToSpaces(2)
         endWithNewline()
     }
 }
@@ -141,7 +131,10 @@ nativeTasks.addToSourceSetResources(sourceSets.test)
 nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpinet")
 nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpiutil")
 nativeConfig.dependencies.add wpilibTools.deps.wpilib("cscore")
-nativeConfig.dependencies.add wpilibTools.deps.wpilibOpenCv("frc" + wpi.frcYear.get(), wpi.versions.opencvVersion.get())
+nativeConfig.dependencies.add wpilibTools.deps.wpilibOpenCv(openCVversion)
 
+wrapper {
+    gradleVersion = "9.4.0"
+}
 
 apply from: "publish.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ wpi.getVersions().getWpimathVersion().convention(wpimathVersion);
 wpilibTools.deps.wpilibVersion = wpilibVersion
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=permwrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/org/photonvision/rknn/RknnTest.java
+++ b/src/test/java/org/photonvision/rknn/RknnTest.java
@@ -19,7 +19,7 @@ package org.photonvision.rknn;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.wpi.first.util.CombinedRuntimeLoader;
+import org.photonvision.jni.CombinedRuntimeLoader;
 import java.io.IOException;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/photonvision/rknn/RknnTest.java
+++ b/src/test/java/org/photonvision/rknn/RknnTest.java
@@ -19,13 +19,13 @@ package org.photonvision.rknn;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.photonvision.jni.CombinedRuntimeLoader;
 import java.io.IOException;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.imgcodecs.Imgcodecs;
+import org.photonvision.jni.CombinedRuntimeLoader;
 import org.photonvision.rknn.RknnJNI.ModelVersion;
 
 public class RknnTest {

--- a/versioningHelper.gradle
+++ b/versioningHelper.gradle
@@ -8,11 +8,8 @@ gradle.allprojects {
         def stdout = new ByteArrayOutputStream()
         String tagIsh
         try {
-            exec {
-                commandLine 'git', 'describe', '--tags', "--match=v*"
-                standardOutput = stdout
-            }
-            tagIsh = stdout.toString().trim().toLowerCase()
+           def line = "git describe --tags --match=v*".execute().text.trim().readLines().last()
+            tagIsh = line.toString().trim().toLowerCase()
         } catch (Exception e) {
             tagIsh = "dev-Unknown"
         }

--- a/versioningHelper.gradle
+++ b/versioningHelper.gradle
@@ -8,7 +8,7 @@ gradle.allprojects {
         def stdout = new ByteArrayOutputStream()
         String tagIsh
         try {
-           def line = "git describe --tags --match=v*".execute().text.trim().readLines().last()
+            def line = "git describe --tags --match=v*".execute().text.trim().readLines().last()
             tagIsh = line.toString().trim().toLowerCase()
         } catch (Exception e) {
             tagIsh = "dev-Unknown"


### PR DESCRIPTION
Bumps opencv + other dependencies:

```
matth@DESKTOP-PNNHDMI:~/photonvision$ /home/matth/.gradle/toolchains/first/2025/arm64/bin/aarch64-bookworm-linux-gnu-readelf -d /mnt/c/Users/matth/Downloads/librknn-Release/librknn_jni.so 

Dynamic section at offset 0xfd20 contains 34 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [librknnrt.so]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_core.so.413]
 0x0000000000000001 (NEEDED)             Shared library: [libopencv_imgproc.so.413]
 0x0000000000000001 (NEEDED)             Shared library: [librga.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
 0x000000000000000e (SONAME)             Library soname: [librknn_jni.so]
 0x000000000000001d (RUNPATH)            Library runpath: [/home/runner/work/rknn_jni/rknn_jni/src/main/native/lib:/home/runner/work/rknn_jni/rknn_jni/cmake_build/_deps/opencv_lib-src/linux/arm64/shared:/home/runner/work/rknn_jni/rknn_jni/src/main/native/lib/3rdparty/rga/RK3588/lib/Linux/aarch64:]
```