### PR TITLE
Move CI to arm runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v4
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [validation]
     strategy:
       fail-fast: false
@@ -51,22 +51,16 @@ jobs:
         java-version: 17
         distribution: temurin
 
-    - uses: pguyot/arm-runner-action@v2
-      with:
-        base_image: https://github.com/PhotonVision/photon-image-modifier/releases/download/v2025.0.0-beta-7/photonvision_opi5.img.xz
-        cpu: cortex-a7
-        image_additional_mb: 1500
-        bind_mount_repository: true
-        commands: |
-            apt-get update
-            apt-get install -y cmake build-essential default-jdk openjdk-17-jdk binutils
-            ls
-            find .
-            pwd
-            cmake -B cmake_build -S . -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_INSTALL_PREFIX=cmake_build -DOPENCV_ARCH=linuxarm64 ${{ matrix.extra-cmake-args }}
-            cmake --build cmake_build --target install -- -j 4
-            ldd cmake_build/lib/*.so
-            readelf -d cmake_build/lib/*.so
+    - run: |
+        apt-get update
+        apt-get install -y cmake build-essential default-jdk openjdk-17-jdk binutils
+        ls
+        find .
+        pwd
+        cmake -B cmake_build -S . -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_INSTALL_PREFIX=cmake_build -DOPENCV_ARCH=linuxarm64 ${{ matrix.extra-cmake-args }}
+        cmake --build cmake_build --target install -- -j 4
+        ldd cmake_build/lib/*.so
+        readelf -d cmake_build/lib/*.so
 
     - run: find .
 
@@ -83,22 +77,3 @@ jobs:
       with:
         name: librknn-${{ matrix.jar-name }}
         path: cmake_build/*.so
-
-    # Push to dev release on pushes to master
-    - uses: pyTooling/Actions/releaser@r6
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag: 'Dev'
-        rm: true
-        files: |
-          cmake_build/*.so
-      if: github.event_name == 'push' && (startsWith(matrix.build-type, 'Release'))
-
-    # Push to actual release, if tagged
-    - uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          cmake_build/*.so
-      if: startsWith(github.ref, 'refs/tags/v') && (startsWith(matrix.build-type, 'Release'))
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,8 @@ jobs:
         distribution: temurin
 
     - run: |
-        apt-get update
-        apt-get install -y cmake build-essential default-jdk openjdk-17-jdk binutils
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential default-jdk openjdk-17-jdk binutils
         ls
         find .
         pwd


### PR DESCRIPTION
Moves CI off pguyot/arm-runner to use the default github arm runner. This makes it quite a bit faster, and follows https://github.com/photonvision/tflite_jni